### PR TITLE
add pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "rack-cors"
 gem "representable"
 gem "multi_json"
 gem "config"
+gem "kaminari", '~> 1.2'
 gem "bootsnap", ">= 1.4.4", require: false
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,18 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jwt (2.7.1)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -294,6 +306,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   jbuilder (~> 2.7)
+  kaminari (~> 1.2)
   listen (~> 3.3)
   multi_json
   mysql2

--- a/app/controllers/api/admin/posts_controller.rb
+++ b/app/controllers/api/admin/posts_controller.rb
@@ -1,8 +1,8 @@
 class Api::Admin::PostsController < Api::Admin::BaseController
   def index
-    blogs = Post.all
+    posts = Post.all
 
-    render json: blogs, except: %i(updated_at deleted_at)
+    render_paginated(posts, serializer: PostsRepresenter)
   end
 
   def create

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::PostsController < Api::V1::BaseController
   def index
     posts = Post.publish
 
-    render json: PostsRepresenter.new(posts).to_json
+    render_paginated(posts, serializer: PostsRepresenter)
   end
 
   def show

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include Pagination
+
   skip_forgery_protection
   before_action :authorize_request!
   rescue_from Api::Error, with: :handle_api_error

--- a/app/controllers/concerns/pagination.rb
+++ b/app/controllers/concerns/pagination.rb
@@ -1,0 +1,22 @@
+module Pagination
+  extend ActiveSupport::Concern
+
+  included do
+
+    def render_paginated(collection, serializer: nil)
+      paginated = collection.page(params[:page]).per(params[:per_page] || Settings.pagination.max_per_page)
+      meta = {
+        current_page: paginated.current_page,
+        next_page: paginated.next_page,
+        previous_page: paginated.prev_page,
+        total_pages: paginated.total_pages,
+        total_count: paginated.total_count,
+        next_page_url: paginated.next_page.present? ? url_for(page: paginated.next_page) : nil,
+        previous_page_url: paginated.prev_page.present? ? url_for(page: paginated.prev_page) : nil
+      }
+      
+      response = { data: serializer ? serializer.new(paginated) : paginated, meta: meta }
+      render json: response
+    end
+  end
+end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,3 +7,5 @@ authorization:
   header: JWTAuthorization
   grant_refresh_token_type: refresh_token
   access_token_type: Bearer
+pagination:
+  max_per_page: 10

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-5.times do
+10.times do
   post = Post.create!(
     title: Faker::Book.title,
     content: Faker::Lorem.paragraphs,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced pagination support for posts in API responses.
	- Added a new `Pagination` module to manage paginated responses.
	- Configured the Kaminari pagination library for future customization.
	- Added a new pagination configuration setting with a maximum of 10 items per page.

- **Bug Fixes**
	- Improved clarity in variable naming for posts in the API controllers.

- **Chores**
	- Increased the number of seeded `Post` records from five to ten in the database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->