### PR TITLE
Using presignURL to upload image

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "ransack"
 gem "kaminari", '~> 1.2'
 gem "logtail-rails"
 gem "bootsnap", ">= 1.4.4", require: false
+gem "aws-sdk-s3", require: false
 
 # Serializer
 gem 'active_model_serializers', '~> 0.10.13'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,25 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1141.0)
+    aws-sdk-core (3.229.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.110.0)
+      aws-sdk-core (~> 3, >= 3.228.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.196.0)
+      aws-sdk-core (~> 3, >= 3.228.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bcrypt (3.1.20)
     benchmark (0.4.1)
@@ -168,6 +187,7 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jmespath (1.6.2)
     jsonapi-renderer (0.2.2)
     jwt (2.10.2)
       base64
@@ -402,6 +422,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.13)
+  aws-sdk-s3
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.4)
   byebug

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,22 +1,13 @@
 class Post < ApplicationRecord
-  include Rails.application.routes.url_helpers
-
   acts_as_paranoid
   enum category: { news: 0, finance: 1 }
   enum status: { pending: 0, publish: 1 }
 
   belongs_to :user, optional: true
-  has_one_attached :image
 
   scope :with_category_name, lambda { |name|
     categories.key?(name) ? where(category: categories[name]) : none
   }
-
-  def image_url
-    return unless image.attached?
-
-    url_for(image)
-  end
 
   def self.ransackable_scopes(auth_object = nil)
     %i[with_category_name]

--- a/app/services/s3_storage_service.rb
+++ b/app/services/s3_storage_service.rb
@@ -1,0 +1,72 @@
+require "aws-sdk-s3"
+require "securerandom"
+
+class S3StorageService
+  DEFAULT_TMP_PREFIX = "tmp/".freeze
+  DEFAULT_UPLOADS_PREFIX = "uploads/".freeze
+
+  def initialize(access_key_id: ENV["AWS_ACCESS_KEY_ID"], secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"], region: ENV["AWS_REGION"], bucket_name: ENV["S3_BUCKET_NAME"])
+    @access_key_id = access_key_id
+    @secret_access_key = secret_access_key
+    @region = region
+    @bucket_name = bucket_name
+  end
+
+  # Tạo presigned URL dạng PUT để client upload trực tiếp lên S3
+  # Trả về hash { url:, key: }
+  def generate_presigned_put_url(filename:, content_type:, expires_in: 600, tmp_prefix: DEFAULT_TMP_PREFIX)
+    key = "#{tmp_prefix}#{SecureRandom.uuid}/#{filename}"
+    obj = s3_resource.bucket(@bucket_name).object(key)
+    url = obj.presigned_url(:put, expires_in: expires_in, content_type: content_type)
+    { url: url, key: key }
+  end
+
+  # "Promote" file từ thư mục tạm (tmp/) sang thư mục chính (uploads/)
+  # Trả về hash { key:, url: }
+  def promote_tmp_object(tmp_key, destination_prefix: DEFAULT_UPLOADS_PREFIX)
+    unless tmp_key&.start_with?(DEFAULT_TMP_PREFIX)
+      return { key: tmp_key, url: public_url_for(tmp_key) }
+    end
+
+    upload_key = tmp_key.sub(/^#{Regexp.escape(DEFAULT_TMP_PREFIX)}/, destination_prefix)
+    s3_client.copy_object(
+      bucket: @bucket_name,
+      copy_source: "#{@bucket_name}/#{tmp_key}",
+      key: upload_key
+    )
+
+    { key: upload_key, url: public_url_for(upload_key) }
+  end
+
+  def delete_object(key)
+    return unless key.present?
+
+    s3_client.delete_object(bucket: @bucket_name, key: key)
+  rescue Aws::S3::Errors::NoSuchKey
+    Rails.logger.error("No such key: #{key}")
+  end
+
+  private
+
+  def public_url_for(key)
+    "https://#{@bucket_name}.s3.#{@region}.amazonaws.com/#{key}"
+  end
+
+  def s3_resource
+    @s3_resource ||= Aws::S3::Resource.new(
+      access_key_id: @access_key_id,
+      secret_access_key: @secret_access_key,
+      region: @region
+    )
+  end
+
+  def s3_client
+    @s3_client ||= Aws::S3::Client.new(
+      access_key_id: @access_key_id,
+      secret_access_key: @secret_access_key,
+      region: @region
+    )
+  end
+end
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       resources :posts, only: %i[index create destroy update show] do
         collection do
           get :categories
+          post :presign
         end
       end
     end

--- a/db/migrate/20250816041202_add_image_key_for_posts.rb
+++ b/db/migrate/20250816041202_add_image_key_for_posts.rb
@@ -1,0 +1,5 @@
+class AddImageKeyForPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :posts, :image_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_05_31_084922) do
-
+ActiveRecord::Schema[7.1].define(version: 2025_08_16_041202) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
@@ -30,7 +29,7 @@ ActiveRecord::Schema.define(version: 2025_05_31_084922) do
     t.string "service_name", null: false
     t.bigint "byte_size", null: false
     t.string "checksum", null: false
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
@@ -45,12 +44,13 @@ ActiveRecord::Schema.define(version: 2025_05_31_084922) do
     t.text "content", size: :long
     t.text "description"
     t.integer "category", default: 0
-    t.datetime "deleted_at"
+    t.datetime "deleted_at", precision: nil
     t.integer "status", default: 0
     t.text "image_url"
     t.bigint "user_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "image_key"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
@@ -60,14 +60,14 @@ ActiveRecord::Schema.define(version: 2025_05_31_084922) do
     t.date "date_of_birth"
     t.string "phone_number"
     t.integer "role", default: 0
-    t.datetime "deleted_at"
+    t.datetime "deleted_at", precision: nil
     t.string "encrypted_password", null: false
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
+    t.datetime "reset_password_sent_at", precision: nil
+    t.datetime "remember_created_at", precision: nil
     t.string "refresh_token"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "avatar_url"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["refresh_token"], name: "index_users_on_refresh_token", unique: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Admin posts support direct browser-to-cloud image uploads via a new presign endpoint.
  - Images are tracked by key, become immediately available after upload, and can be promoted/replaced on create/update.
  - Images are automatically removed when a post is deleted.

- **Chores**
  - Added cloud storage SDK dependency to enable presigned uploads and in-bucket promotion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->